### PR TITLE
Remove 'state' parameter - no longer in spec.

### DIFF
--- a/src/pages/keys.mdx
+++ b/src/pages/keys.mdx
@@ -93,8 +93,7 @@ Detached-JWS: eyJiNjQiOmZhbHNlLCJhbGciOiJSUzI1NiIsImtpZCI6Inh5ei0xIn0..Y287HMtaY
     ],
     "interact": {
         "type": "redirect",
-        "callback": "https://client.example.net/return/123455",
-        "state": "LKLTI25DK82FX4T4QFZC"
+        "callback": "https://client.example.net/return/123455"
     },
     "key": {
 		"proof": "jwsd",
@@ -137,8 +136,7 @@ Digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
     ],
     "interact": {
         "type": "redirect",
-        "callback": "https://client.example.net/return/123455",
-        "state": "LKLTI25DK82FX4T4QFZC"
+        "callback": "https://client.example.net/return/123455"
     },
     "key": {
 		"proof": "httpsig",
@@ -178,8 +176,7 @@ Content-Type: application/json
     ],
     "interact": {
         "type": "redirect",
-        "callback": "https://client.example.net/return/123455",
-        "state": "LKLTI25DK82FX4T4QFZC"
+        "callback": "https://client.example.net/return/123455"
     },
     "key": {
         "cert": "MIIEHDCCAwSgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBmjE3MDUGA1UEAwwuQmVzcG9rZSBFbmdpbmVlcmluZyBSb290IENlcnRpZmljYXRlIEF1dGhvcml0eTELMAkGA1UECAwCTUExCzAJBgNVBAYTAlVTMRkwFwYJKoZIhvcNAQkBFgpjYUBic3BrLmlvMRwwGgYDVQQKDBNCZXNwb2tlIEVuZ2luZWVyaW5nMQwwCgYDVQQLDANNVEkwHhcNMTkwNDEwMjE0MDI5WhcNMjQwNDA4MjE0MDI5WjB8MRIwEAYDVQQDDAlsb2NhbGhvc3QxCzAJBgNVBAgMAk1BMQswCQYDVQQGEwJVUzEgMB4GCSqGSIb3DQEJARYRdGxzY2xpZW50QGJzcGsuaW8xHDAaBgNVBAoME0Jlc3Bva2UgRW5naW5lZXJpbmcxDDAKBgNVBAsMA01USTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMmaXQHbs/wc1RpsQ6Orzf6rN+q2ijaZbQxD8oi+XaaN0P/gnE13JqQduvdq77OmJ4bQLokqsd0BexnI07Njsl8nkDDYpe8rNve5TjyUDCfbwgS7U1CluYenXmNQbaYNDOmCdHwwUjV4kKREg6DGAx22Oq7+VHPTeeFgyw4kQgWRSfDENWY3KUXJlb/vKR6lQ+aOJytkvj8kVZQtWupPbvwoJe0na/ISNAOhL74w20DWWoDKoNltXsEtflNljVoi5nqsmZQcjfjt6LO0T7O1OX3Cwu2xWx8KZ3n/2ocuRqKEJHqUGfeDtuQNt6Jz79v/OTr8puLWaD+uyk6NbtGjoQsCAwEAAaOBiTCBhjAJBgNVHRMEAjAAMAsGA1UdDwQEAwIF4DBsBgNVHREEZTBjgglsb2NhbGhvc3SCD3Rsc2NsaWVudC5sb2NhbIcEwKgBBIERdGxzY2xpZW50QGJzcGsuaW+GF2h0dHA6Ly90bHNjbGllbnQubG9jYWwvhhNzc2g6dGxzY2xpZW50LmxvY2FsMA0GCSqGSIb3DQEBCwUAA4IBAQCKKv8WlLrT4Z5NazaUrYtlTF+2v0tvZBQ7qzJQjlOqAcvxry/d2zyhiRCRS/v318YCJBEv4Iq2W3I3JMMyAYEe2573HzT7rH3xQP12yZyRQnetdiVM1Z1KaXwfrPDLs72hUeELtxIcfZ0M085jLboXhufHI6kqm3NCyCCTihe2ck5RmCc5l2KBO/vAHF0ihhFOOOby1v6qbPHQcxAU6rEb907/p6BW/LV1NCgYB1QtFSfGxowqb9FRIMD2kvMSmO0EMxgwZ6k6spa+jk0IsI3klwLW9b+Tfn/daUbIDctxeJneq2anQyU2znBgQl6KILDSF4eaOqlBut/KNZHHazJh"

--- a/src/pages/transactionresponse.mdx
+++ b/src/pages/transactionresponse.mdx
@@ -34,7 +34,7 @@ If a `display_handle` is returned by the AS, the client can use this handle in l
 
 ## Interact Handle
 
-If an `interact_handle` is returned by the AS, the client can use this handle in lieu of the `interact` portion of the transaction request in future transactions. However, for a redirect based interaction, as this section includes the `state` value which is supposed to be unguessable and unique per transaction, this response doesn't make sense in such cases.
+If an `interact_handle` is returned by the AS, the client can use this handle in lieu of the `interact` portion of the transaction request in future transactions.
 
 ## User Handle
 


### PR DESCRIPTION
Removes `"state"` param from examples, as previously discussed.

Addresses issue #7.